### PR TITLE
Update version of Instaparse and Clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject scijors "0.1.4"
+(defproject scijors "0.1.5"
   :description "An easy to use, ultra-high performance, HTML-based Clojure templating library."
   :url "https://github.com/cosmi/scijors"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [instaparse "1.2.7"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [instaparse "1.4.9"]])
 
 


### PR DESCRIPTION
This pull request updates version of Instaparse, allowing update of Clojure (since Clojure 1.7.0 broke earlier versions of Instaparse).